### PR TITLE
Define missing properties

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -28,23 +28,23 @@ class Client
 
     const API_KEY = null;
 
-    protected $access;
-    protected $auth_method;
-    protected $issues;
-    protected $comments;
-    protected $teams;
-    protected $projects;
-    protected $issue_labels;
-    protected $views;
-    protected $reactions;
-    protected $favorites;
-    protected $api_keys;
-    protected $emojis;
-    protected $user_settings;
-    protected $users;
-    protected $cycles;
-    protected $documents;
-    protected $webhooks;
+    public $access;
+    public $auth_method;
+    public $issues;
+    public $comments;
+    public $teams;
+    public $projects;
+    public $issue_labels;
+    public $views;
+    public $reactions;
+    public $favorites;
+    public $api_keys;
+    public $emojis;
+    public $user_settings;
+    public $users;
+    public $cycles;
+    public $documents;
+    public $webhooks;
 
     public function __construct($api_key, $auth_method = self::AUTH_METHOD)
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -28,6 +28,24 @@ class Client
 
     const API_KEY = null;
 
+    protected $access;
+    protected $auth_method;
+    protected $issues;
+    protected $comments;
+    protected $teams;
+    protected $projects;
+    protected $issue_labels;
+    protected $views;
+    protected $reactions;
+    protected $favorites;
+    protected $api_keys;
+    protected $emojis;
+    protected $user_settings;
+    protected $users;
+    protected $cycles;
+    protected $documents;
+    protected $webhooks;
+
     public function __construct($api_key, $auth_method = self::AUTH_METHOD)
     {
         if ($api_key) {


### PR DESCRIPTION
When using this library on newer versions of PHP, we get the following error:

```
Undefined property: LinearApi\Client::$access
```

This PR fixes that issue by defining the properties in the class. It's backwards compatible with older versions.

PHP 8.2 and above allows you to strictly type the properties, but I've avoided doing that here because the package doesn't specify a requirement of PHP 8.2 and above.

